### PR TITLE
Partie 2 - Tri par ordre alphabétique

### DIFF
--- a/microcommerce/src/main/java/com/ecommerce/microcommerce/dao/ProductDao.java
+++ b/microcommerce/src/main/java/com/ecommerce/microcommerce/dao/ProductDao.java
@@ -28,6 +28,8 @@ public interface ProductDao extends JpaRepository<Product, Integer>{
 	  @Query("SELECT id, nom, prix FROM Product p WHERE p.prix > :prixLimit")
 	  List<Product> chercherUnProduitCher(@Param("prixLimit") int prix);
 
+	List<Product> findAllByOrderByNomAsc();
+
 	
 	 
 }

--- a/microcommerce/src/main/java/com/ecommerce/microcommerce/web/controller/ProductController.java
+++ b/microcommerce/src/main/java/com/ecommerce/microcommerce/web/controller/ProductController.java
@@ -39,12 +39,12 @@ public class ProductController {
 	@Autowired
 	private ProductDao productDao;
 	SimpleBeanPropertyFilter monFiltre;
-//	@RequestMapping(value = "/Produits", method = RequestMethod.GET)
-//	public List<Product> listeProduits() {
-//		monFiltre =
-//				SimpleBeanPropertyFilter.serializeAllExcept("prixAchat");
-//		return productDao.findAll();
-//	}
+	//	@RequestMapping(value = "/Produits", method = RequestMethod.GET)
+	//	public List<Product> listeProduits() {
+	//		monFiltre =
+	//				SimpleBeanPropertyFilter.serializeAllExcept("prixAchat");
+	//		return productDao.findAll();
+	//	}
 
 	@RequestMapping(value = "/Produits", method = RequestMethod.GET)
 	public MappingJacksonValue listeProduitsfiltre() {
@@ -56,7 +56,17 @@ public class ProductController {
 		produitsFiltres.setFilters(listeDeNosFiltres);
 		return produitsFiltres;
 	}
-	
+
+	@RequestMapping(value = "/ProduitsOrdonnnerParNom", method = RequestMethod.GET)
+	public MappingJacksonValue trierProduitsParOrdreAlphabetique () {
+		List<Product> produits = productDao.findAllByOrderByNomAsc();
+		monFiltre = SimpleBeanPropertyFilter.serializeAllExcept("prixAchat");
+		FilterProvider listeDeNosFiltres = new
+				SimpleFilterProvider().addFilter("monFiltreDynamique", monFiltre);
+		MappingJacksonValue produitsFiltres = new MappingJacksonValue(produits);
+		produitsFiltres.setFilters(listeDeNosFiltres);
+		return produitsFiltres;
+	}
 
 
 	@GetMapping(value = "/AdminProduits") 


### PR DESCRIPTION
La méthode  trierProduitsParOrdreAlphabetique doit impérativement faire appel à une méthode que vous allez ajouter dans ProductDao  qui utilise le nommage conventionné de Spring Data JPA pour générer automatiquement les requêtes. Voici le résultat à obtenir avec le contenu de la base de données du cours :
{
{
"id": 2,
"nom": "Aspirateur Robot",
"prix": 500,
"prixAchat": 200
},
{
"id": 1,
"nom": "Ordinateur portable",
"prix": 350,
"prixAchat": 120
},
{
"id": 3,
"nom": "Table de Ping Pong",
"prix": 750,
"prixAchat": 400
}
}